### PR TITLE
Graphite port is not passed correctly when rendering graphs

### DIFF
--- a/lib/descartes/public/js/render-common.js
+++ b/lib/descartes/public/js/render-common.js
@@ -99,7 +99,7 @@ var parseUrl = function(url) {
     protocol: a.protocol.replace(':',''),
     host: a.hostname,
     port: (function(){
-      if(a.port) {
+      if (a.port) {
         return a.port;
       } else if (a.protocol == 'https:') {
         return 443;


### PR DESCRIPTION
I noticed this while redoing my development setup tonight where graphite is listening on a port other than 80.

Simply ensure the port is always passed when rendering a graph in the browser.

:heart:
