### PR TITLE
Fix Details toggle in graph profile

### DIFF
--- a/lib/descartes/public/js/profile-graph.js
+++ b/lib/descartes/public/js/profile-graph.js
@@ -198,14 +198,14 @@ var gatherTags = function(cb) {
   });
 };
 
-// Invert details button when opened
-$('div.well').on('click', 'a.details.btn.closed', function() {
-  $(this).text('Close Details').removeClass('closed').addClass('open').addClass('btn-inverse');
-});
-
-// Revert details button when closed
-$('div.well').on('click', 'a.details.btn.open', function() {
-  $(this).text('Details').removeClass('open').addClass('closed').removeClass('btn-inverse');
+// Invert details button mode when activated
+$(window).on('click', 'a.details.btn', function() {
+  if ($('fieldset.in.collapse').length > 0) {
+    resetFieldsetFormAndButtons($(this).attr('data-target'));
+    $(this).text('Close Details').addClass('btn-inverse');
+  } else {
+    $(this).text('Details').removeClass('btn-inverse');
+  }
 });
 
 // Convert description span into editable textarea

--- a/lib/descartes/public/js/render-common.js
+++ b/lib/descartes/public/js/render-common.js
@@ -284,6 +284,7 @@ var resetFieldsetFormAndButtons = function(target) {
     $('fieldset.collapse' + target).addClass('in').css('height', 'auto');
     $('a.import.btn').text('Import Graphs').removeClass('btn-inverse');
     $('a.dashboard.btn').text('Add to Dashboard').removeClass('btn-inverse');
+    $('a.details.btn').text('Details').removeClass('btn-inverse');
 };
 
 // Enable the auto-refresh mode


### PR DESCRIPTION
This fixes a condition where clicking on the "Details" button and then clicking on the "Add to Dashboard" button would leave the Details button inverted. Updated the `a.details.btn` event binding to act like other panel buttons elsewhere.
