### PR TITLE
Set credentials for gist data

### DIFF
--- a/lib/descartes/public/js/profile-graph.js
+++ b/lib/descartes/public/js/profile-graph.js
@@ -135,6 +135,14 @@ var renderGraphs = function() {
     selectNullModeButton();
     $.ajax({
       accepts: {json: 'application/json'},
+      beforeSend: function(xhr) {
+        var creds = graphiteUser + ':' + graphitePass;
+        if (creds.length > 1) {
+          var bytes = Crypto.charenc.Binary.stringToBytes(creds);
+          var base64 = Crypto.util.bytesToBase64(bytes);
+          xhr.setRequestHeader('Authorization', 'Basic ' + base64);
+        }
+      },
       cache: false,
       dataType: 'json',
       error: function(xhr, textStatus, errorThrown) { console.log(errorThrown); },


### PR DESCRIPTION
We need to set http credentials (if available) for our gist json query as well. Same pattern we use elsewhere.
