### PR TITLE
Fix error preventing graph saving under new Sinatra.

### DIFF
--- a/lib/descartes/routes/graphs.rb
+++ b/lib/descartes/routes/graphs.rb
@@ -156,8 +156,11 @@ module Descartes
     end
 
     put '/graphs/:id/?' do
+      # Obtain graph based on URL path parameter
       @graph = Graph.filter(:uuid => params[:id]).first
-      params.delete('id')
+      # Filter out id + other non-form-field params (modern Sinatra adds e.g.
+      # 'splat') so they don't anger Sequel
+      params.delete_if {|k, v| %w(id splat captures).include?(k)}
       if params[:overrides]
         # check to see if our data came in as a String (e.g. curl) or real JSON (from Descartes UI)
         overrides = params[:overrides].class.eql?(String) ? JSON.parse(params[:overrides]) : params[:overrides]


### PR DESCRIPTION
Newer Sinatra updates the `params` hash with some "meta" keys like `splat` and `captures`; this is not accounted for & causes Sequel to error on those keys as they are not valid DB fields.
