### PR TITLE
Fixes #166. Previous version worked if GRAPHITE_USER and GRAPHITE_PASS e...

### DIFF
--- a/lib/descartes/models/metrics.rb
+++ b/lib/descartes/models/metrics.rb
@@ -19,7 +19,8 @@ class Metric
 
   def self.update
     u = URI.parse(ENV['GRAPHITE_URL'])
-    if (!ENV['GRAPHITE_USER'].empty? && !ENV['GRAPHITE_PASS'].empty?)
+    if (ENV.has_key?('GRAPHITE_USER') && !ENV['GRAPHITE_USER'].empty? &&
+        ENV.has_key?('GRAPHITE_PASS') && !ENV['GRAPHITE_PASS'].empty?)
       u.user = ENV['GRAPHITE_USER']
       u.password = CGI.escape(ENV['GRAPHITE_PASS'])
     end


### PR DESCRIPTION
Fixes #166. Previous version worked if GRAPHITE_USER and GRAPHITE_PASS existed

and were either empty or valued. Addition means it also works if the variables
are unset.
